### PR TITLE
Add BuildRequires for openssl-devel, bzip2-devel and readline-devel

### DIFF
--- a/rpm/python3-base.spec
+++ b/rpm/python3-base.spec
@@ -24,6 +24,9 @@ BuildRequires:  pkgconfig
 BuildRequires:  xz
 BuildRequires:  zlib-devel
 BuildRequires:  sqlite-devel
+BuildRequires:  openssl-devel
+BuildRequires:  bzip2-devel
+BuildRequires:  readline-devel
 BuildRequires:  python
 Url:            http://www.python.org/
 Summary:        Python3 Interpreter
@@ -278,6 +281,12 @@ rm -rf $RPM_BUILD_ROOT
 %{dynlib unicodedata}
 %{dynlib zlib}
 %{dynlib _sqlite3}
+%{dynlib _bz2}
+%{dynlib _curses}
+%{dynlib _curses_panel}
+%{dynlib _hashlib}
+%{dynlib _ssl}
+%{dynlib readline}
 %{dynlib pyexpat}
 # hashlib fallback modules
 %{dynlib _md5}


### PR DESCRIPTION
CC @thp
- openssl-devel: support https
- bzip2-devel: support bzip2
- readline-devel: browsable buffer for console/repl
